### PR TITLE
Issue 3: add MAINTAINERS file

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,3 @@
+Flavio Junqueira <fpj@pravega.io>
+Derek Moore <derekm@pravega.io>
+Srikanth Satya <Srikanth.Satya@dell.com>


### PR DESCRIPTION
Initial Steering Committee for Pravega org (a.k.a., MAINTAINERS file or OWNERS file at the CNCF)

Authoritative source for https://maintainers.cncf.io/

Fixes #3